### PR TITLE
Example muon integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,61 @@
             <scope>test</scope>
         </dependency>
 
+
+        <!-- muon config -->
+        <dependency>
+            <groupId>io.muoncore</groupId>
+            <artifactId>muon-core</artifactId>
+            <version>7.3.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.muoncore</groupId>
+            <artifactId>test-event-store</artifactId>
+            <version>0.0.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.muoncore.transport</groupId>
+            <artifactId>muon-amqp</artifactId>
+            <version>0.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>io.muoncore.protocol</groupId>
+            <artifactId>stack-event</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.muoncore.protocol</groupId>
+            <artifactId>stack-rpc</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.muoncore.protocol</groupId>
+            <artifactId>stack-reactive-streams</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>21.0</version>
+        </dependency>
+
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>muon</id>
+            <name>muoncore-releases</name>
+            <url>https://simplicityitself.jfrog.io/simplicityitself/muon</url>
+        </repository>
+        <repository>
+            <id>muonsnap</id>
+            <name>muoncore-releases</name>
+            <url>https://simplicityitself.jfrog.io/simplicityitself/muon-snapshot</url>
+            <snapshots></snapshots>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>


### PR DESCRIPTION
This PR contains an example of how you would use muon comms to implement distributed event communication based on persisted event streams.

It is not intended to be merged as is and is to stimulate a conversation.

The prod setup will have a muon instance for the rockescript server and an EventClient that is then used to interact with some event system somewhere. This could be remote and standalone (eg, Photonlite -> http://github.com/muoncore/photonlite), or it could be any other implementation of the event stack. We have plans for a variety of implementations, covering systems such as Kafka, Cassandra and the like.  If this is adopted, you wouldn't need to change your application code beyond what is implemented here.

In `EventStore` I have added the appropriate pieces in to persist and replay events in two types of stream. The first is `rockscript` and contains all events across all executions. The second gives 1 stream per execution, allowing rapid reconstruction of that execution as needed.

This is all running in memory using the InMemTransport and TestEventStore (soon to be moved and renamed InMemEventStore).  This gives you something that works similarly to your existing event store, but is muon API compatible with all of the other event engines we support.

There are a few improvements above the state of the code as is, but I wanted to ping it over to see if its something you want to look into beyond this at all.

David.